### PR TITLE
Fix test script and add basic Jest suite

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Dollars not Sense
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Stop tweeting about the game—sign and become the glitch.
 
 ## Getting Started
 
-This repository contains a very small Express server as a starting point. To run it locally:
+This repository contains a very small Express server serving a static home page. To run it locally:
 
 ```bash
 npm install
 npm start
 ```
 
-Open `http://localhost:3000` in your browser.
+Open `http://localhost:3000` in your browser. The home page lives in `public/index.html` and can be customized with your own copy or styling.
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ The project uses Jest for basic testing. After installing dependencies, run:
 npm test
 ```
 
+### Continuous Integration
+
+This project uses GitHub Actions to automatically run `npm test` on every pull
+request. The workflow configuration resides in
+`.github/workflows/nodejs.yml`.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# labelsite
+# Dollars not Sense
+
+**Dollars not Sense** is a digital label focused on signing and promoting independent artists. We handle the infrastructure that usually hides behind major labels—studio time, viral campaigns, brand connections, and PR support—without the traditional gatekeeping.
+
+## Pitch
+
+Everybody swears they "independent" till the TikTok gods ignore them and the majors ghost-write the narrative. Skip the begging. We hand you the same invisible jetpack the majors keep under lock-and-key—no million-dollar recoup, no A&R babysitter, no prayer-circle playlist pitching. Sign this plant-level pact and we turn your raw feed into a runway: studio slots, viral scaffolding, brand collabs, PR smoke—all pre-wired, all friction-free, all in our house.
+
+You drop, we spin the dial. Your clips land in the right explore tabs, your numbers swell, your email lights up with blue-check DMs you never met. Behind the curtain? Our private furnace of accounts, partnerships, and data rope-pulls does the heavy lift your cousin’s “marketing agency” can’t picture, let alone replicate. We front the muscle, skim our cut, and ship the wins straight to your dashboard in real time.
+
+No gate, no shelf clause, no hidden exec veto. Want out? Cool—buy back the keys at fair market and walk. Want in? Today’s the cheapest you’ll ever catch this ticket, because once the majors clock the scent we’ll raise the ante and slam the door.
+
+Stop tweeting about the game—sign and become the glitch.
+
+## Getting Started
+
+This repository contains a very small Express server as a starting point. To run it locally:
+
+```bash
+npm install
+npm start
+```
+
+Open `http://localhost:3000` in your browser.
+
+### Running Tests
+
+The project uses Jest for basic testing. After installing dependencies, run:
+
+```bash
+npm test
+```
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
 const express = require('express');
+const path = require('path');
 const app = express();
 
+// Serve static assets from the public directory
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Default route serves the home page
 app.get('/', (req, res) => {
-  res.send('Welcome to Dollars not Sense!');
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 if (require.main === module) {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const app = express();
+
+app.get('/', (req, res) => {
+  res.send('Welcome to Dollars not Sense!');
+});
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "labelsite",
+  "version": "1.0.0",
+  "description": "Digital label site for independent artists",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.4",
+    "supertest": "^6.3.4"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dollars not Sense</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Dollars not Sense</h1>
+    <p class="tagline">Become the glitch.</p>
+  </header>
+  <main>
+    <section class="pitch">
+      <p>Everybody swears they "independent" till the TikTok gods ignore them and the majors ghost-write the narrative. Skip the begging. We hand you the same invisible jetpack the majors keep under lock-and-key—no million-dollar recoup, no A&R babysitter, no prayer-circle playlist pitching.</p>
+      <p>Sign this plant-level pact and we turn your raw feed into a runway: studio slots, viral scaffolding, brand collabs, PR smoke—all pre-wired, all friction-free, all in our house.</p>
+      <p>You drop, we spin the dial. Your clips land in the right explore tabs, your numbers swell, your email lights up with blue-check DMs you never met.</p>
+      <p>No gate, no shelf clause, no hidden exec veto. Want out? Cool—buy back the keys at fair market and walk. Stop tweeting about the game—sign and become the glitch.</p>
+    </section>
+    <section class="signup">
+      <h2>Get Signed</h2>
+      <form>
+        <label>
+          Email
+          <input type="email" required />
+        </label>
+        <label>
+          Latest Link
+          <input type="url" required />
+        </label>
+        <label>
+          Unreleased Tracks
+          <textarea required></textarea>
+        </label>
+        <button type="submit">Submit</button>
+      </form>
+    </section>
+  </main>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,45 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #fafafa;
+  color: #333;
+}
+header {
+  background: #111;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+.tagline {
+  font-style: italic;
+}
+main {
+  padding: 1rem;
+  max-width: 800px;
+  margin: auto;
+}
+section.pitch p {
+  margin-bottom: 1rem;
+}
+section.signup {
+  margin-top: 2rem;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+input,
+textarea {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+button {
+  padding: 0.7rem;
+  font-size: 1rem;
+  background: #111;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,9 +2,10 @@ const request = require('supertest');
 const app = require('../index');
 
 describe('GET /', () => {
-  it('responds with welcome message', async () => {
+  it('serves the home page HTML', async () => {
     const response = await request(app).get('/');
     expect(response.status).toBe(200);
-    expect(response.text).toBe('Welcome to Dollars not Sense!');
+    expect(response.headers['content-type']).toMatch(/html/);
+    expect(response.text).toContain('<title>Dollars not Sense</title>');
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /', () => {
+  it('responds with welcome message', async () => {
+    const response = await request(app).get('/');
+    expect(response.status).toBe(200);
+    expect(response.text).toBe('Welcome to Dollars not Sense!');
+  });
+});


### PR DESCRIPTION
## Summary
- update server to allow testing without immediate startup
- switch to MIT license in package.json
- add Jest and Supertest with basic test
- document test usage in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c3ea4c4d4832496a9bff7a0267a1d